### PR TITLE
normally dont sudo brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is meant for people who are new to emacs and want to get running quickly.
 
 To install ```git clone https://github.com/nosami/omnisharp-demo.git ~/.emacs.d```
 
-For OSX, use http://emacsformacosx.com/ or ```sudo brew install emacs -cocoa --with-gnutls```
+For OSX, use http://emacsformacosx.com/ or ```brew install emacs -cocoa --with-gnutls```
 
 For Windows, use http://emacsbinw64.sourceforge.net/
 


### PR DESCRIPTION
Normally on macs you don't run brew as root.

Error: Cowardly refusing to `sudo brew install`
You can use brew with sudo, but only if the brew executable is owned by root.
However, this is both not recommended and completely unsupported so do so at
your own risk.
